### PR TITLE
CI cleanup: drop unused --trace, opt into Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -62,8 +62,8 @@ VERILATOR_FLAGS += -O3
 VERILATOR_FLAGS += -Wall
 # Compile
 #VERILATOR_FLAGS += --build
-# Make waveforms
-VERILATOR_FLAGS += --trace
+# Make waveforms (disabled — no VCD dumper is wired up in prog_keccak.cpp)
+#VERILATOR_FLAGS += --trace
 # Check SystemVerilog assertions
 VERILATOR_FLAGS += --assert
 # Generate coverage analysis


### PR DESCRIPTION
## Summary
- Drop unused \`--trace\` from Verilator flags — \`prog_keccak.cpp\` never wires up a \`VerilatedVcdC\`, so the flag only produced a runtime \"previous dump at t=N\" warning and slowed the build
- Set \`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true\` workflow env to opt into Node 24, silencing the deprecation annotation \`upload-artifact@v5\` still emits

## Test plan
- [x] \`make\` clean locally, output matches reference vectors
- [x] CI green
- [ ] No Node 20 deprecation annotation on the new run

🤖 Generated with [Claude Code](https://claude.com/claude-code)
