### PR TITLE
README: clarify Keccak-f[1600] vs FIPS 202 SHA-3

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,23 @@ keccak-verilog
 
 [![CI](https://github.com/jmoles/keccak-verilog/actions/workflows/ci.yml/badge.svg)](https://github.com/jmoles/keccak-verilog/actions/workflows/ci.yml)
 
-A Verilog (specifically, SystemVerilog) implementation of Keccak, the algorithm standardized as SHA-3 in [FIPS 202](https://csrc.nist.gov/publications/detail/fips/202/final) (August 2015). This is for a SystemVerilog class project. This design was validated with Questa and Veloce. I presented it as part of class on 6 June 2013 and the presentation is available [here](https://docs.google.com/presentation/d/1fEvkiKvQkEGiJ8LwQPkU6PK8SjZtGHqMSyf2X4v82iY/).
+A SystemVerilog implementation of the Keccak-f[1600] permutation and sponge construction, translated from the [Keccak team's reference VHDL distribution](https://keccak.team/hardware.html). Originally a SystemVerilog class project, presented on 6 June 2013 (slides [here](https://docs.google.com/presentation/d/1fEvkiKvQkEGiJ8LwQPkU6PK8SjZtGHqMSyf2X4v82iY/)) and validated at the time with QuestaSim and Mentor Veloce.
+
+## What this implements
+
+The core in this repo is the **Keccak-f[1600] permutation** wrapped in a sponge that absorbs **pre-padded** input blocks. The padding policy is the *caller's* responsibility — whatever bytes you put in the input blocks, the core absorbs.
+
+That makes it usable for either flavor of Keccak-derived hash, depending on which domain-separator byte the caller inserts before applying `pad10*1`:
+
+| Hash | Domain separator | Used by |
+|---|---|---|
+| Original Keccak (e.g. Keccak-256) | none / `0x01` | Ethereum, the original [Keccak submission](https://keccak.team/) |
+| SHA-3 (SHA3-224/256/384/512) | `0x06` | NIST [FIPS 202](https://csrc.nist.gov/publications/detail/fips/202/final) (August 2015) |
+| SHAKE128 / SHAKE256 | `0x1F` | NIST FIPS 202 |
+
+The Keccak-f[1600] permutation itself is identical across all of these and is what FIPS 202 standardizes — only the pre-permutation padding differs.
+
+The bundled test vectors in `test_vectors/` come directly from the Keccak team's reference VHDL distribution (`KeccakVHDL-3.1/new_test_vector/`), which validates against the **original Keccak** padding. The core has not been independently validated against NIST's [CAVP test vectors](https://csrc.nist.gov/projects/cryptographic-algorithm-validation-program/secure-hashing) for SHA-3 — that would be a worthwhile addition for anyone wanting to use it as a FIPS 202 implementation.
 
 I updated this design in April 2021 to run with [Verilator](https://verilator.org/). Prior to then, it ran with QuestaSim. The original design also targeted Mentor Veloce for emulation, but I no longer have access to that environment.
 


### PR DESCRIPTION
Adds a 'What this implements' section noting that the core is the Keccak-f[1600] permutation, padding-agnostic, and can be driven as original Keccak, SHA-3, or SHAKE depending on the caller's domain separator. Also notes the bundled vectors validate against original Keccak, not NIST CAVP.